### PR TITLE
Return the element

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,4 +19,6 @@ module.exports = function (css, options) {
     } else {
         head.appendChild(elem);
     }
+
+    return elem;
 };

--- a/readme.markdown
+++ b/readme.markdown
@@ -51,3 +51,12 @@ blob with inline css!
   </body>
 </html>
 ```
+
+Should you want to get rid of the styles we’ve inserted, it’s easy as pie:
+
+``` js
+const myStyles = insertCss('whatever {}');
+// Styles are in
+myStyles.parentNode.removeChild(myStyles);
+// Styles are out
+```

--- a/test/insert.js
+++ b/test/insert.js
@@ -5,8 +5,8 @@ var getStyle = require('computed-style');
 var css = 'body { background-color: purple; color: yellow; }';
 
 test(function (t) {
-    t.plan(10);
-    
+    t.plan(13);
+
     var before = colors();
     t.ok(before.bg === 'rgba(0,0,0,0)' || before.bg === 'transparent');
     t.ok(before.fg === 'rgb(0,0,0)' || before.fg === '#000000');
@@ -37,6 +37,12 @@ test(function (t) {
     var reset = colors();
     t.ok(reset.bg === 'rgb(255,255,0)' || reset.bg === 'yellow');
     t.ok(reset.fg === 'rgb(128,0,128)' || reset.fg === 'purple');
+
+    var styleElement = insertCss('whatever {}');
+    t.ok(styleElement instanceof Element);
+    t.ok(document.documentElement.contains(styleElement));
+    styleElement.parentNode.removeChild(styleElement);
+    t.notOk(document.documentElement.contains(styleElement));
 });
 
 function colors () {


### PR DESCRIPTION
With this PR it’s possible to grap a reference to the `<style>` element we create. To remove it afterwards or something.

My use case: I’m writing unit tests for my CSS. I need to get rid of the styles after every test.