### PR TITLE
Custom `document`

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,13 @@ var inserted = {};
 module.exports = function (css, options) {
     if (inserted[css]) return;
     inserted[css] = true;
-    
-    var elem = document.createElement('style');
+
+    var doc =
+        (options && options.document) ||
+        (typeof document !== 'undefined' && document)
+    ;
+
+    var elem = doc.createElement('style');
     elem.setAttribute('type', 'text/css');
 
     if ('textContent' in elem) {
@@ -12,8 +17,8 @@ module.exports = function (css, options) {
     } else {
       elem.styleSheet.cssText = css;
     }
-    
-    var head = document.getElementsByTagName('head')[0];
+
+    var head = doc.getElementsByTagName('head')[0];
     if (options && options.prepend) {
         head.insertBefore(elem, head.childNodes[0]);
     } else {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,15 @@
     "dependencies": {},
     "devDependencies": {
         "tape": "^2.13.3",
+        "jsdom": "^6.5.0",
         "computed-style": "~0.1.3"
     },
     "repository": {
         "type": "git",
         "url": "git://github.com/substack/insert-css.git"
+    },
+    "browser" : {
+        "jsdom": false
     },
     "testling" : {
         "files" : "test/*.js",

--- a/readme.markdown
+++ b/readme.markdown
@@ -51,3 +51,11 @@ blob with inline css!
   </body>
 </html>
 ```
+
+If you’re running this module outside a browser, you can pass a custom instance of `document`:
+
+``` js
+var doc = require('jsdom').jsdom('<!DOCTYPE html>').defaultView.document;
+
+insertCss(css, { document: doc });
+```

--- a/test/insert.js
+++ b/test/insert.js
@@ -3,6 +3,10 @@ var insertCss = require('../');
 var getStyle = require('computed-style');
 
 var css = 'body { background-color: purple; color: yellow; }';
+var doc =
+    (typeof document !== 'undefined' && document) ||
+    require('jsdom').jsdom('<!DOCTYPE html>').defaultView.document
+;
 
 test(function (t) {
     t.plan(10);
@@ -10,29 +14,29 @@ test(function (t) {
     var before = colors();
     t.ok(before.bg === 'rgba(0,0,0,0)' || before.bg === 'transparent');
     t.ok(before.fg === 'rgb(0,0,0)' || before.fg === '#000000');
-    
-    insertCss(css, { prepend: true });
-    
+
+    insertCss(css, { prepend: true, document: doc });
+
     var after = colors();
     t.ok(after.bg === 'rgb(128,0,128)' || after.bg === 'purple');
     t.ok(after.fg === 'rgb(255,255,0)' || after.fg === 'yellow');
 
     var resetStyle = 'body { background-color: transparent; color: #000000; }';
-    insertCss(resetStyle);
+    insertCss(resetStyle, { document: doc });
 
     var reset = colors();
     t.ok(reset.bg === 'rgba(0,0,0,0)' || reset.bg === 'transparent');
     t.ok(reset.fg === 'rgb(0,0,0)' || reset.fg === '#000000');
 
     var resetStyle = 'body { background-color: green; color: pink; }';
-    insertCss(resetStyle, { prepend: true });
+    insertCss(resetStyle, { prepend: true, document: doc });
 
     var reset = colors();
     t.ok(reset.bg === 'rgba(0,0,0,0)' || reset.bg === 'transparent');
     t.ok(reset.fg === 'rgb(0,0,0)' || reset.fg === '#000000');
 
     var resetStyle = 'body { background-color: yellow; color: purple; }';
-    insertCss(resetStyle, { prepend: false });
+    insertCss(resetStyle, { prepend: false, document: doc });
 
     var reset = colors();
     t.ok(reset.bg === 'rgb(255,255,0)' || reset.bg === 'yellow');
@@ -40,7 +44,7 @@ test(function (t) {
 });
 
 function colors () {
-    var body = document.getElementsByTagName('body')[0];
+    var body = doc.getElementsByTagName('body')[0];
     return {
         bg: getStyle(body, 'backgroundColor').replace(/\s+/g, ''),
         fg: getStyle(body, 'color').replace(/\s+/g, '')


### PR DESCRIPTION
Hi,

I need to run this module outside a browser. How about passing a custom implementation of `document`?

Unfortunately the tests rely on http://npm.im/computed-style – so they still don’t pass in node. It seems like jsdom [does have](https://github.com/tmpvar/jsdom/blob/3fe618a66d2dde772f502046e00f109137d5fe49/lib/jsdom/browser/Window.js#L274-L316) basic support for getComputedStyle. So when I find some time I’ll open a PR in computed-style to take custom DOM as well.

No need to merge this yet as long as tests don’t pass.