### PR TITLE
Don’t prevent inserting the same CSS twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 var inserted = {};
 
 module.exports = function (css, options) {
-    if (inserted[css]) return;
-    inserted[css] = true;
-    
     var elem = document.createElement('style');
     elem.setAttribute('type', 'text/css');
 

--- a/test/insert.js
+++ b/test/insert.js
@@ -39,6 +39,17 @@ test(function (t) {
     t.ok(reset.fg === 'rgb(128,0,128)' || reset.fg === 'purple');
 });
 
+test('Allow inserting the same CSS twice', function (t) {
+    t.plan(2);
+
+    var resetStyle = 'body { background-color: transparent; color: #000000; }';
+    insertCss(resetStyle);
+
+    var reset = colors();
+    t.ok(reset.bg === 'rgba(0,0,0,0)' || reset.bg === 'transparent');
+    t.ok(reset.fg === 'rgb(0,0,0)' || reset.fg === '#000000');
+});
+
 function colors () {
     var body = document.getElementsByTagName('body')[0];
     return {


### PR DESCRIPTION
@substack what’s the reason for these? https://github.com/substack/insert-css/blob/acc7f4688a6e4b1ce2d5ebdbedb90e93385f991c/index.js#L4-L5

I can’t find a test for that – and I don’t see a reason too. I guess it’s the author of an app who should care for not inserting a style twice – not a library.

It’s been causing me problems when testing stuff. I add styles before every test and remove them afterwards.