### PR TITLE
Fix cannot read property of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function insertCss(css, options) {
     }
 
     // strip potential UTF-8 BOM if css was read from a file
-    if (css.charCodeAt(0) === 0xFEFF) { css = css.substr(1, css.length); }
+    if (css && css.charCodeAt(0) === 0xFEFF) { css = css.substr(1, css.length); }
 
     // actually add the stylesheet
     if (styleElement.styleSheet) {


### PR DESCRIPTION
The fix for potential UTF-8 BOM can fail, because `css` can be undefined. This PR adds a check to make sure `css`is defined.