### PR TITLE
fix(substr): remove useless string.length

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function insertCss(css, options) {
     }
 
     // strip potential UTF-8 BOM if css was read from a file
-    if (css.charCodeAt(0) === 0xFEFF) { css = css.substr(1, css.length); }
+    if (css.charCodeAt(0) === 0xFEFF) { css = css.substr(1); }
 
     // actually add the stylesheet
     if (styleElement.styleSheet) {


### PR DESCRIPTION
According to MDN, substr's default behaviour is to return the rest of the string
using css.length consumes unnecessary computation
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr